### PR TITLE
fix(telegram): handle CommonJS module interop in Node

### DIFF
--- a/src/platforms/telegram/tdlib-node-test.ts
+++ b/src/platforms/telegram/tdlib-node-test.ts
@@ -1,0 +1,19 @@
+import { TdjsonBinding } from './tdlib'
+
+function fail(message: string): never {
+  console.error(message)
+  process.exit(1)
+}
+
+if (typeof (globalThis as { Bun?: unknown }).Bun !== 'undefined') {
+  fail('Expected Node.js runtime, but Bun was detected')
+}
+
+const binding = await TdjsonBinding.create()
+const version = binding.execute({ '@type': 'getOption', name: 'version' })
+
+if (version?.['@type'] !== 'optionValueString' || typeof version.value !== 'string') {
+  fail(`Expected TDLib version, got: ${JSON.stringify(version)}`)
+}
+
+console.log('ok')

--- a/src/platforms/telegram/tdlib-node.test.ts
+++ b/src/platforms/telegram/tdlib-node.test.ts
@@ -1,0 +1,11 @@
+import { expect, it } from 'bun:test'
+import { execSync } from 'node:child_process'
+
+it('loads TDLib in Node.js', () => {
+  const result = execSync('bun tsx src/platforms/telegram/tdlib-node-test.ts', {
+    cwd: process.cwd(),
+    encoding: 'utf-8',
+  })
+
+  expect(result.trim()).toBe('ok')
+})

--- a/src/platforms/telegram/tdlib.ts
+++ b/src/platforms/telegram/tdlib.ts
@@ -7,6 +7,10 @@ interface TdjsonSymbols {
   td_execute: (request: string) => string | null
 }
 
+function unwrapDefaultExport<T>(moduleNamespace: T): T {
+  return (moduleNamespace as T & { default?: T }).default ?? moduleNamespace
+}
+
 let cachedKoffi: typeof import('koffi') | undefined
 
 async function getKoffi(): Promise<typeof import('koffi')> {
@@ -15,7 +19,7 @@ async function getKoffi(): Promise<typeof import('koffi')> {
   }
 
   try {
-    cachedKoffi = await import('koffi')
+    cachedKoffi = unwrapDefaultExport(await import('koffi'))
     return cachedKoffi
   } catch {
     throw new Error('koffi is required for Telegram support. Install it with: bun add koffi prebuilt-tdlib')
@@ -36,7 +40,7 @@ function getLibrarySuffix(): string {
 
 async function getPrebuiltTdjsonPath(): Promise<string | undefined> {
   try {
-    const mod = (await import('prebuilt-tdlib')) as { getTdjson?: () => string }
+    const mod = unwrapDefaultExport((await import('prebuilt-tdlib')) as { getTdjson?: () => string })
     const tdjson = mod.getTdjson?.()
     return typeof tdjson === 'string' && tdjson.length > 0 ? tdjson : undefined
   } catch {


### PR DESCRIPTION
## Summary

- normalize CommonJS default exports returned by dynamic `import()` before using Telegram native dependencies
- apply the same interop handling to both `koffi` and `prebuilt-tdlib`
- add a Node.js regression test that loads TDLib and queries its version

## Problem

The published npm CLI runs under Node.js. Node exposes the CommonJS Koffi export under `default`, while Bun also exposes `load` as a named export. The loader called `koffi.load` directly on the imported namespace, so every TDLib candidate failed with `koffi.load is not a function` even when the shared library was present.

## Testing

- `bun run test` — 3,733 passed
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `bun run build`
- loaded the built binding with Node.js and queried TDLib version 1.8.62


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Telegram TDLib loading in Node.js by unwrapping CommonJS default exports from dynamic imports. Previously, Node exposed `koffi` and `prebuilt-tdlib` under `default`, so `koffi.load` was undefined; now we unwrap `default`, restoring TDLib initialization in Node without changing Bun behavior.

- Add `unwrapDefaultExport` and apply it to `koffi` and `prebuilt-tdlib`.
- Add a Node regression test that loads TDLib and asserts the version is returned.
- No API or configuration changes; `koffi` and `prebuilt-tdlib` remain required for Telegram support.
- Docs/SKILL.md: no changes.

<sup>Written for commit 00fef7ae393bee79e70d7ce3c1b542a29030674e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/328?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

