### PR TITLE
fix(kakaotalk): classify room lookup and complete chat pagination

### DIFF
--- a/src/platforms/kakaotalk/chat-classifier.test.ts
+++ b/src/platforms/kakaotalk/chat-classifier.test.ts
@@ -30,4 +30,26 @@ describe('classifyKakaoChat', () => {
   it('classifies a 1-member chat (lone room) as dm', () => {
     expect(classifyKakaoChat({ type: 11, active_members: 1 })).toBe('dm')
   })
+
+  for (const type of ['DirectChat', 'MultiChat', 'PlusChat', 'MemoChat'] as const) {
+    it(`keeps member-count classification for known normal type ${type}`, () => {
+      expect(classifyKakaoChat({ type, active_members: 2 })).toBe('dm')
+      expect(classifyKakaoChat({ type, active_members: 3 })).toBe('group')
+    })
+  }
+
+  it('classifies an unknown string type as unknown regardless of member count', () => {
+    expect(
+      classifyKakaoChat({
+        type: 'UnknownChat',
+        active_members: 2,
+      }),
+    ).toBe('unknown')
+    expect(
+      classifyKakaoChat({
+        type: 'UnknownChat',
+        active_members: 3,
+      }),
+    ).toBe('unknown')
+  })
 })

--- a/src/platforms/kakaotalk/chat-classifier.ts
+++ b/src/platforms/kakaotalk/chat-classifier.ts
@@ -1,4 +1,4 @@
-import type { KakaoChat, KakaoOpenChatType } from './types'
+import { isKnownKakaoChatStringType, type KakaoChat, type KakaoOpenChatType } from './types'
 
 export type KakaoChatKind = 'dm' | 'group' | 'open' | 'unknown'
 
@@ -21,12 +21,15 @@ export function isOpenKakaoChatType(type: unknown): type is KakaoOpenChatType {
  * NOT "simplify" this back to a pure type-code mapping without verifying
  * against a real KakaoTalk session.
  *
- * `'unknown'` is reserved for future protocol drift; the current heuristic
- * never returns it, but it is part of the union so consumers can handle
- * the case defensively.
+ * `'unknown'` is reserved for future string protocol drift so consumers fail
+ * closed instead of silently classifying an unrecognized server value by
+ * member count.
  */
 export function classifyKakaoChat(chat: Pick<KakaoChat, 'type' | 'active_members'>): KakaoChatKind {
   if (isOpenKakaoChatType(chat.type)) return 'open'
+  if (typeof chat.type === 'string' && !isKnownKakaoChatStringType(chat.type)) {
+    return 'unknown'
+  }
   // active_members counts the logged-in user, so a 1:1 DM is exactly 2
   // (self + one other) and a "lone" room with only self is 1.
   if (chat.active_members <= 2) return 'dm'

--- a/src/platforms/kakaotalk/client.test.ts
+++ b/src/platforms/kakaotalk/client.test.ts
@@ -1230,6 +1230,40 @@ describe('KakaoTalkClient', () => {
       client.close()
     })
 
+    it('classifies a successful CHATINFO response with null chatInfo as structurally absent', async () => {
+      const secretSentinel = 'secret-null-chat-body-do-not-emit'
+      const chatIdSentinel = '987654321012345678'
+      mockGetChannelInfo.mockResolvedValueOnce({
+        statusCode: 0,
+        body: { chatInfo: null, secret: secretSentinel },
+      })
+
+      const client = await new KakaoTalkClient().login({ oauthToken: 'token', userId: 'user1', deviceUuid: 'device1' })
+
+      let error: unknown
+      try {
+        await client.getChat(chatIdSentinel)
+      } catch (cause) {
+        error = cause
+      }
+
+      expect(error).toBeInstanceOf(KakaoTalkError)
+      expect(error).toMatchObject({
+        code: 'get_chat_failed',
+        getChatFailureReason: 'chat_info_absent',
+        responseFailureKind: 'transient_or_unknown',
+      })
+      const serialized = JSON.stringify(error)
+      expect(serialized).not.toContain(secretSentinel)
+      expect(serialized).not.toContain('body')
+      expect(serialized).not.toContain('message')
+      expect(serialized).not.toContain('cause')
+      expect(serialized).not.toContain('chatId')
+      expect(serialized).not.toContain(chatIdSentinel)
+
+      client.close()
+    })
+
     it('classifies malformed successful CHATINFO chatInfo as transport or unknown', async () => {
       mockGetChannelInfo.mockResolvedValueOnce({
         statusCode: 0,

--- a/src/platforms/kakaotalk/client.test.ts
+++ b/src/platforms/kakaotalk/client.test.ts
@@ -1034,6 +1034,7 @@ describe('KakaoTalkClient', () => {
           chatInfo: {
             chatId: makeLong(300),
             type: 11,
+            left: false,
             activeMembersCount: 2,
             newMessageCount: 4,
             invalidNewMessageCount: false,
@@ -1263,6 +1264,99 @@ describe('KakaoTalkClient', () => {
 
       client.close()
     })
+
+    it('classifies exact CHATINFO left=true as structurally absent without exposing response contents', async () => {
+      const secretSentinel = 'secret-left-chat-body-do-not-emit'
+      const nativeChatIdSentinel = '987654321'
+      mockGetChannelInfo.mockResolvedValueOnce({
+        statusCode: 0,
+        body: {
+          chatInfo: {
+            left: true,
+            chatId: makeLong(Number(nativeChatIdSentinel)),
+            secret: secretSentinel,
+          },
+        },
+      })
+
+      const client = await new KakaoTalkClient().login({ oauthToken: 'token', userId: 'user1', deviceUuid: 'device1' })
+
+      let error: unknown
+      try {
+        await client.getChat(nativeChatIdSentinel)
+      } catch (cause) {
+        error = cause
+      }
+
+      expect(error).toBeInstanceOf(KakaoTalkError)
+      expect(error).toMatchObject({
+        code: 'get_chat_failed',
+        getChatFailureReason: 'chat_info_absent',
+        responseFailureKind: 'transient_or_unknown',
+      })
+      const publicError = error as KakaoTalkError
+      const serialized = JSON.stringify(publicError)
+      expect(publicError.message).not.toContain(secretSentinel)
+      expect(publicError.message).not.toContain(nativeChatIdSentinel)
+      expect(serialized).not.toContain(secretSentinel)
+      expect(serialized).not.toContain(nativeChatIdSentinel)
+
+      client.close()
+    })
+
+    for (const [label, chatInfo] of [
+      ['mismatched chatId', { left: true, chatId: makeLong(301) }],
+      ['missing chatId', { left: true }],
+      ['invalid chatId', { left: true, chatId: { invalid: true } }],
+    ] as const) {
+      it(`does not classify CHATINFO left=true with ${label} as structurally absent`, async () => {
+        mockGetChannelInfo.mockResolvedValueOnce({
+          statusCode: 0,
+          body: { chatInfo },
+        })
+
+        const client = await new KakaoTalkClient().login({
+          oauthToken: 'token',
+          userId: 'user1',
+          deviceUuid: 'device1',
+        })
+
+        await expect(client.getChat('300')).rejects.toMatchObject({
+          code: 'get_chat_failed',
+          getChatFailureReason: 'transport_or_unknown',
+          responseFailureKind: 'transient_or_unknown',
+        })
+
+        client.close()
+      })
+    }
+
+    for (const [label, chatInfo] of [
+      ['left=false', { left: false }],
+      ['left missing', {}],
+      ['left nonboolean', { left: 'true' }],
+    ] as const) {
+      it(`does not classify malformed successful CHATINFO with ${label} as structurally absent`, async () => {
+        mockGetChannelInfo.mockResolvedValueOnce({
+          statusCode: 0,
+          body: { chatInfo },
+        })
+
+        const client = await new KakaoTalkClient().login({
+          oauthToken: 'token',
+          userId: 'user1',
+          deviceUuid: 'device1',
+        })
+
+        await expect(client.getChat('300')).rejects.toMatchObject({
+          code: 'get_chat_failed',
+          getChatFailureReason: 'transport_or_unknown',
+          responseFailureKind: 'transient_or_unknown',
+        })
+
+        client.close()
+      })
+    }
 
     it('classifies malformed successful CHATINFO chatInfo as transport or unknown', async () => {
       mockGetChannelInfo.mockResolvedValueOnce({

--- a/src/platforms/kakaotalk/client.test.ts
+++ b/src/platforms/kakaotalk/client.test.ts
@@ -500,7 +500,9 @@ describe('KakaoTalkClient', () => {
       mockLogin.mockResolvedValue(emptyLoginResult)
 
       mockGetChatList.mockResolvedValueOnce({
+        statusCode: 0,
         body: {
+          status: 0,
           chatDatas: [
             {
               c: 100,
@@ -559,7 +561,9 @@ describe('KakaoTalkClient', () => {
       mockLogin.mockResolvedValue(loginResult)
 
       mockGetChatList.mockResolvedValueOnce({
+        statusCode: 0,
         body: {
+          status: 0,
           chatDatas: [
             {
               c: 300,
@@ -596,7 +600,9 @@ describe('KakaoTalkClient', () => {
 
       // Return a chat with same ID as login result
       mockGetChatList.mockResolvedValueOnce({
+        statusCode: 0,
         body: {
+          status: 0,
           chatDatas: [
             {
               c: 100, // Same as first login chat
@@ -630,7 +636,9 @@ describe('KakaoTalkClient', () => {
       mockLogin.mockResolvedValue(loginResult)
 
       mockGetChatList.mockResolvedValueOnce({
+        statusCode: 0,
         body: {
+          status: 0,
           chatDatas: [
             {
               c: makeLong(300),
@@ -658,6 +666,148 @@ describe('KakaoTalkClient', () => {
       expect(paginatedChat?.display_name).toBe('Dave')
       expect(paginatedChat?.last_message?.author_name).toBe('Dave')
       expect(chats.some((chat) => chat.chat_id === '[object Object]')).toBe(false)
+
+      client.close()
+    })
+
+    it('collects every LCHATLIST page until an explicit EOF', async () => {
+      mockLogin.mockResolvedValue({ ...DEFAULT_LOGIN_RESULT, eof: false })
+      mockGetChatList
+        .mockResolvedValueOnce({
+          statusCode: 0,
+          body: {
+            status: 0,
+            chatDatas: [
+              {
+                c: 300,
+                t: 1,
+                k: ['Dave'],
+                i: [4],
+                a: 1,
+                n: 0,
+                o: 1698000000,
+                l: null,
+                ll: makeLong(100),
+              },
+            ],
+            lastTokenId: makeLong(1),
+            lastChatId: makeLong(300),
+            eof: false,
+          },
+        })
+        .mockResolvedValueOnce({
+          statusCode: 0,
+          body: {
+            status: 0,
+            chatDatas: [
+              {
+                c: 400,
+                t: 1,
+                k: ['Erin'],
+                i: [5],
+                a: 1,
+                n: 0,
+                o: 1697000000,
+                l: null,
+                ll: makeLong(90),
+              },
+            ],
+            lastTokenId: makeLong(2),
+            lastChatId: makeLong(400),
+            eof: true,
+          },
+        })
+
+      const client = await new KakaoTalkClient().login({ oauthToken: 'token', userId: 'user1', deviceUuid: 'device1' })
+      const chats = await client.getChats({ all: true })
+
+      expect(chats.map((chat) => chat.chat_id)).toEqual(['100', '200', '300', '400'])
+      expect(mockGetChatList).toHaveBeenCalledTimes(2)
+
+      client.close()
+    })
+
+    it('fails closed when LCHATLIST has a nonzero response status', async () => {
+      mockLogin.mockResolvedValue({ ...DEFAULT_LOGIN_RESULT, eof: false })
+      mockGetChatList.mockResolvedValueOnce({
+        statusCode: 503,
+        body: { status: 0, chatDatas: [], lastTokenId: makeLong(1), lastChatId: makeLong(300), eof: true },
+      })
+
+      const client = await new KakaoTalkClient().login({ oauthToken: 'token', userId: 'user1', deviceUuid: 'device1' })
+
+      await expect(client.getChats({ all: true })).rejects.toMatchObject({
+        code: 'get_chats_failed',
+        responseFailureKind: 'provider_rejection',
+        serverStatus: 503,
+      })
+
+      client.close()
+    })
+
+    it('fails closed on an empty non-EOF LCHATLIST page', async () => {
+      mockLogin.mockResolvedValue({ ...DEFAULT_LOGIN_RESULT, eof: false })
+      mockGetChatList.mockResolvedValueOnce({
+        statusCode: 0,
+        body: { status: 0, chatDatas: [], lastTokenId: makeLong(1), lastChatId: makeLong(300), eof: false },
+      })
+
+      const client = await new KakaoTalkClient().login({ oauthToken: 'token', userId: 'user1', deviceUuid: 'device1' })
+
+      await expect(client.getChats({ all: true })).rejects.toMatchObject({ code: 'get_chats_failed' })
+      expect(mockGetChatList).toHaveBeenCalledTimes(1)
+
+      client.close()
+    })
+
+    it('fails closed when LCHATLIST reaches the page cap without EOF', async () => {
+      mockLogin.mockResolvedValue({ ...DEFAULT_LOGIN_RESULT, eof: false })
+      let page = 0
+      mockGetChatList.mockImplementation(async () => {
+        page++
+        return {
+          statusCode: 0,
+          body: {
+            status: 0,
+            chatDatas: [
+              {
+                c: 1000 + page,
+                t: 1,
+                k: [`Room ${page}`],
+                i: [1000 + page],
+                a: 1,
+                n: 0,
+                o: 1600000000 - page,
+                l: null,
+                ll: makeLong(page),
+              },
+            ],
+            lastTokenId: makeLong(page),
+            lastChatId: makeLong(1000 + page),
+            eof: false,
+          },
+        }
+      })
+
+      const client = await new KakaoTalkClient().login({ oauthToken: 'token', userId: 'user1', deviceUuid: 'device1' })
+
+      await expect(client.getChats({ all: true })).rejects.toMatchObject({ code: 'get_chats_failed' })
+      expect(mockGetChatList).toHaveBeenCalledTimes(50)
+
+      client.close()
+    })
+
+    it('preserves non-all search compatibility on an empty non-EOF page', async () => {
+      mockLogin.mockResolvedValue({ ...DEFAULT_LOGIN_RESULT, eof: false })
+      mockGetChatList.mockResolvedValueOnce({
+        body: { chatDatas: [], lastTokenId: makeLong(1), lastChatId: makeLong(300), eof: false },
+      })
+
+      const client = await new KakaoTalkClient().login({ oauthToken: 'token', userId: 'user1', deviceUuid: 'device1' })
+      const chats = await client.getChats({ search: 'Alice' })
+
+      expect(chats.map((chat) => chat.chat_id)).toEqual(['100'])
+      expect(mockGetChatList).toHaveBeenCalledTimes(1)
 
       client.close()
     })
@@ -922,6 +1072,122 @@ describe('KakaoTalkClient', () => {
           message: 'latest',
           sent_at: 1700000077,
         },
+      })
+
+      client.close()
+    })
+
+    it('classifies an explicit CHATINFO header rejection without exposing response contents', async () => {
+      mockGetChannelInfo.mockResolvedValueOnce({ statusCode: 403, body: {} })
+
+      const client = await new KakaoTalkClient().login({ oauthToken: 'token', userId: 'user1', deviceUuid: 'device1' })
+
+      await expect(client.getChat('300')).rejects.toMatchObject({
+        code: 'get_chat_failed',
+        responseFailureKind: 'provider_rejection',
+        responseStatusSource: 'packet',
+        serverStatus: 403,
+      })
+
+      client.close()
+    })
+
+    it('classifies an explicit CHATINFO body rejection and preserves its numeric status', async () => {
+      mockGetChannelInfo.mockResolvedValueOnce({ statusCode: 0, body: { status: -404 } })
+
+      const client = await new KakaoTalkClient().login({ oauthToken: 'token', userId: 'user1', deviceUuid: 'device1' })
+
+      await expect(client.getChat('300')).rejects.toMatchObject({
+        code: 'get_chat_failed',
+        responseFailureKind: 'provider_rejection',
+        responseStatusSource: 'body',
+        serverStatus: -404,
+      })
+
+      client.close()
+    })
+
+    it('does not expose rejected CHATINFO body contents through public error metadata', async () => {
+      const secretSentinel = 'secret-sentinel-do-not-emit'
+      mockGetChannelInfo.mockResolvedValueOnce({
+        statusCode: 0,
+        body: { status: -404, secret: secretSentinel },
+      })
+
+      const client = await new KakaoTalkClient().login({ oauthToken: 'token', userId: 'user1', deviceUuid: 'device1' })
+      let error: unknown
+      try {
+        await client.getChat('300')
+      } catch (cause) {
+        error = cause
+      }
+
+      expect(error).toBeInstanceOf(KakaoTalkError)
+      const publicError = error as KakaoTalkError
+      expect(publicError).toMatchObject({
+        code: 'get_chat_failed',
+        responseFailureKind: 'provider_rejection',
+        responseStatusSource: 'body',
+        serverStatus: -404,
+      })
+      expect(publicError.message).not.toContain(secretSentinel)
+      expect(JSON.stringify(publicError)).not.toContain(secretSentinel)
+      expect(JSON.stringify(publicError.cause)).not.toContain(secretSentinel)
+
+      client.close()
+    })
+
+    it('classifies synthetic connection-close status -1 as transient rather than provider rejection', async () => {
+      mockGetChannelInfo.mockResolvedValueOnce({ statusCode: -1, body: { error: 'connection closed' } })
+
+      const client = await new KakaoTalkClient().login({ oauthToken: 'token', userId: 'user1', deviceUuid: 'device1' })
+
+      await expect(client.getChat('300')).rejects.toMatchObject({
+        code: 'get_chat_failed',
+        responseFailureKind: 'transient_or_unknown',
+        responseStatusSource: 'packet',
+        serverStatus: -1,
+      })
+
+      client.close()
+    })
+
+    it('does not classify status -1 with a nonmatching body as a synthetic connection close', async () => {
+      mockGetChannelInfo.mockResolvedValueOnce({ statusCode: -1, body: { error: 'provider rejected' } })
+
+      const client = await new KakaoTalkClient().login({ oauthToken: 'token', userId: 'user1', deviceUuid: 'device1' })
+
+      await expect(client.getChat('300')).rejects.toMatchObject({
+        code: 'get_chat_failed',
+        responseFailureKind: 'provider_rejection',
+        responseStatusSource: 'packet',
+        serverStatus: -1,
+      })
+
+      client.close()
+    })
+
+    it('classifies a thrown CHATINFO transport failure as transient or unknown', async () => {
+      mockGetChannelInfo.mockRejectedValueOnce(new Error('socket unavailable'))
+
+      const client = await new KakaoTalkClient().login({ oauthToken: 'token', userId: 'user1', deviceUuid: 'device1' })
+
+      await expect(client.getChat('300')).rejects.toMatchObject({
+        code: 'get_chat_failed',
+        responseFailureKind: 'transient_or_unknown',
+      })
+
+      client.close()
+    })
+
+    it('classifies a malformed successful CHATINFO body as transient or unknown', async () => {
+      mockGetChannelInfo.mockResolvedValueOnce({ statusCode: 0, body: {} })
+
+      const client = await new KakaoTalkClient().login({ oauthToken: 'token', userId: 'user1', deviceUuid: 'device1' })
+
+      await expect(client.getChat('300')).rejects.toMatchObject({
+        code: 'get_chat_failed',
+        responseFailureKind: 'transient_or_unknown',
       })
 
       client.close()

--- a/src/platforms/kakaotalk/client.test.ts
+++ b/src/platforms/kakaotalk/client.test.ts
@@ -242,6 +242,42 @@ describe('KakaoTalkClient', () => {
       client.close()
     })
 
+    it('preserves an unknown non-empty string type from the login snapshot', async () => {
+      mockLogin.mockResolvedValue({
+        ...DEFAULT_LOGIN_RESULT,
+        chatDatas: [{ ...DEFAULT_LOGIN_RESULT.chatDatas[0], t: 'FutureChat' }],
+      })
+
+      const client = await new KakaoTalkClient().login({
+        oauthToken: 'token',
+        userId: 'user1',
+        deviceUuid: 'device1',
+      })
+
+      await expect(client.getChats()).resolves.toMatchObject([{ type: 'FutureChat' }])
+
+      client.close()
+    })
+
+    for (const invalidType of ['', true] as const) {
+      it(`rejects invalid ${JSON.stringify(invalidType)} type from the login snapshot`, async () => {
+        mockLogin.mockResolvedValue({
+          ...DEFAULT_LOGIN_RESULT,
+          chatDatas: [{ ...DEFAULT_LOGIN_RESULT.chatDatas[0], t: invalidType }],
+        })
+
+        const client = await new KakaoTalkClient().login({
+          oauthToken: 'token',
+          userId: 'user1',
+          deviceUuid: 'device1',
+        })
+
+        await expect(client.getChats()).rejects.toMatchObject({ code: 'get_chats_failed' })
+
+        client.close()
+      })
+    }
+
     it('populates last_message.author_name from paired chat.i / chat.k arrays', async () => {
       const client = await new KakaoTalkClient().login({ oauthToken: 'token', userId: 'user1', deviceUuid: 'device1' })
       const chats = await client.getChats()
@@ -1459,13 +1495,55 @@ describe('KakaoTalkClient', () => {
       client.close()
     })
 
-    it('rejects an unknown string CHATINFO type without contacting INFOLINK', async () => {
+    for (const normalChatType of ['DirectChat', 'MultiChat', 'PlusChat', 'MemoChat'] as const) {
+      it(`preserves donor-defined ${normalChatType} without contacting INFOLINK`, async () => {
+        mockGetChannelInfo.mockResolvedValueOnce({
+          statusCode: 0,
+          body: {
+            chatInfo: {
+              chatId: makeLong(300),
+              type: normalChatType,
+              activeMembersCount: 2,
+              newMessageCount: 0,
+              invalidNewMessageCount: false,
+              lastLogId: makeLong(1),
+              lastSeenLogId: makeLong(0),
+              displayMembers: [],
+              chatMetas: [],
+              li: makeLong(7777),
+              pushAlert: true,
+            },
+          },
+        })
+
+        const client = await new KakaoTalkClient().login({
+          oauthToken: 'token',
+          userId: 'user1',
+          deviceUuid: 'device1',
+        })
+
+        await expect(client.getChat('300')).resolves.toEqual({
+          chat_id: '300',
+          type: normalChatType,
+          display_name: null,
+          title: null,
+          active_members: 2,
+          unread_count: 0,
+          last_message: null,
+        })
+        expect(mockGetOpenLinkInfo).not.toHaveBeenCalled()
+
+        client.close()
+      })
+    }
+
+    it('rejects an empty string CHATINFO type without contacting INFOLINK', async () => {
       mockGetChannelInfo.mockResolvedValueOnce({
         statusCode: 0,
         body: {
           chatInfo: {
             chatId: makeLong(300),
-            type: 'UNKNOWN',
+            type: '',
             activeMembersCount: 2,
             newMessageCount: 0,
             invalidNewMessageCount: false,
@@ -1473,7 +1551,6 @@ describe('KakaoTalkClient', () => {
             lastSeenLogId: makeLong(0),
             displayMembers: [],
             chatMetas: [],
-            li: makeLong(7777),
             pushAlert: true,
           },
         },
@@ -1485,7 +1562,50 @@ describe('KakaoTalkClient', () => {
         deviceUuid: 'device1',
       })
 
-      await expect(client.getChat('300')).rejects.toMatchObject({ code: 'get_chat_failed' })
+      await expect(client.getChat('300')).rejects.toMatchObject({
+        code: 'get_chat_failed',
+        getChatFailureReason: 'transport_or_unknown',
+        responseFailureKind: 'transient_or_unknown',
+      })
+      expect(mockGetOpenLinkInfo).not.toHaveBeenCalled()
+
+      client.close()
+    })
+
+    it('preserves an unknown non-empty string CHATINFO type without contacting INFOLINK', async () => {
+      mockGetChannelInfo.mockResolvedValueOnce({
+        statusCode: 0,
+        body: {
+          chatInfo: {
+            chatId: makeLong(300),
+            type: 'UnknownChat',
+            activeMembersCount: 2,
+            newMessageCount: 0,
+            invalidNewMessageCount: false,
+            lastLogId: makeLong(1),
+            lastSeenLogId: makeLong(0),
+            displayMembers: [],
+            chatMetas: [],
+            pushAlert: true,
+          },
+        },
+      })
+
+      const client = await new KakaoTalkClient().login({
+        oauthToken: 'token',
+        userId: 'user1',
+        deviceUuid: 'device1',
+      })
+
+      await expect(client.getChat('300')).resolves.toEqual({
+        chat_id: '300',
+        type: 'UnknownChat',
+        display_name: null,
+        title: null,
+        active_members: 2,
+        unread_count: 0,
+        last_message: null,
+      })
       expect(mockGetOpenLinkInfo).not.toHaveBeenCalled()
 
       client.close()

--- a/src/platforms/kakaotalk/client.test.ts
+++ b/src/platforms/kakaotalk/client.test.ts
@@ -1084,6 +1084,7 @@ describe('KakaoTalkClient', () => {
 
       await expect(client.getChat('300')).rejects.toMatchObject({
         code: 'get_chat_failed',
+        getChatFailureReason: 'provider_rejection',
         responseFailureKind: 'provider_rejection',
         responseStatusSource: 'packet',
         serverStatus: 403,
@@ -1099,6 +1100,7 @@ describe('KakaoTalkClient', () => {
 
       await expect(client.getChat('300')).rejects.toMatchObject({
         code: 'get_chat_failed',
+        getChatFailureReason: 'provider_rejection',
         responseFailureKind: 'provider_rejection',
         responseStatusSource: 'body',
         serverStatus: -404,
@@ -1126,6 +1128,7 @@ describe('KakaoTalkClient', () => {
       const publicError = error as KakaoTalkError
       expect(publicError).toMatchObject({
         code: 'get_chat_failed',
+        getChatFailureReason: 'provider_rejection',
         responseFailureKind: 'provider_rejection',
         responseStatusSource: 'body',
         serverStatus: -404,
@@ -1144,6 +1147,7 @@ describe('KakaoTalkClient', () => {
 
       await expect(client.getChat('300')).rejects.toMatchObject({
         code: 'get_chat_failed',
+        getChatFailureReason: 'synthetic_connection_close',
         responseFailureKind: 'transient_or_unknown',
         responseStatusSource: 'packet',
         serverStatus: -1,
@@ -1159,6 +1163,7 @@ describe('KakaoTalkClient', () => {
 
       await expect(client.getChat('300')).rejects.toMatchObject({
         code: 'get_chat_failed',
+        getChatFailureReason: 'provider_rejection',
         responseFailureKind: 'provider_rejection',
         responseStatusSource: 'packet',
         serverStatus: -1,
@@ -1168,25 +1173,74 @@ describe('KakaoTalkClient', () => {
     })
 
     it('classifies a thrown CHATINFO transport failure as transient or unknown', async () => {
-      mockGetChannelInfo.mockRejectedValueOnce(new Error('socket unavailable'))
+      const secretSentinel = 'secret-transport-body-do-not-emit'
+      mockGetChannelInfo.mockRejectedValueOnce(
+        Object.assign(new Error('socket unavailable'), { body: { secret: secretSentinel } }),
+      )
 
       const client = await new KakaoTalkClient().login({ oauthToken: 'token', userId: 'user1', deviceUuid: 'device1' })
 
-      await expect(client.getChat('300')).rejects.toMatchObject({
+      let error: unknown
+      try {
+        await client.getChat('300')
+      } catch (cause) {
+        error = cause
+      }
+
+      expect(error).toBeInstanceOf(KakaoTalkError)
+      expect(error).toMatchObject({
         code: 'get_chat_failed',
+        getChatFailureReason: 'transport_or_unknown',
         responseFailureKind: 'transient_or_unknown',
       })
+      const serialized = JSON.stringify(error)
+      expect(serialized).not.toContain(secretSentinel)
+      expect(serialized).not.toContain('body')
+      expect(serialized).not.toContain('message')
+      expect(serialized).not.toContain('cause')
 
       client.close()
     })
 
-    it('classifies a malformed successful CHATINFO body as transient or unknown', async () => {
-      mockGetChannelInfo.mockResolvedValueOnce({ statusCode: 0, body: {} })
+    it('classifies a successful CHATINFO response without chatInfo as structurally absent', async () => {
+      const secretSentinel = 'secret-chat-body-do-not-emit'
+      mockGetChannelInfo.mockResolvedValueOnce({ statusCode: 0, body: { secret: secretSentinel } })
+
+      const client = await new KakaoTalkClient().login({ oauthToken: 'token', userId: 'user1', deviceUuid: 'device1' })
+
+      let error: unknown
+      try {
+        await client.getChat('300')
+      } catch (cause) {
+        error = cause
+      }
+
+      expect(error).toBeInstanceOf(KakaoTalkError)
+      expect(error).toMatchObject({
+        code: 'get_chat_failed',
+        getChatFailureReason: 'chat_info_absent',
+        responseFailureKind: 'transient_or_unknown',
+      })
+      const serialized = JSON.stringify(error)
+      expect(serialized).not.toContain(secretSentinel)
+      expect(serialized).not.toContain('body')
+      expect(serialized).not.toContain('message')
+      expect(serialized).not.toContain('cause')
+
+      client.close()
+    })
+
+    it('classifies malformed successful CHATINFO chatInfo as transport or unknown', async () => {
+      mockGetChannelInfo.mockResolvedValueOnce({
+        statusCode: 0,
+        body: { chatInfo: { chatId: makeLong(300) } },
+      })
 
       const client = await new KakaoTalkClient().login({ oauthToken: 'token', userId: 'user1', deviceUuid: 'device1' })
 
       await expect(client.getChat('300')).rejects.toMatchObject({
         code: 'get_chat_failed',
+        getChatFailureReason: 'transport_or_unknown',
         responseFailureKind: 'transient_or_unknown',
       })
 

--- a/src/platforms/kakaotalk/client.ts
+++ b/src/platforms/kakaotalk/client.ts
@@ -1113,7 +1113,16 @@ export class KakaoTalkClient {
         const response = await session.getChannelInfo(parsedChatId)
         assertLocoOk(response, 'CHATINFO')
         const body = response.body as Record<string, unknown>
-        if (body.chatInfo === undefined || body.chatInfo === null) {
+        const chatInfo = body.chatInfo
+        const isLeftChatInfo =
+          chatInfo !== null &&
+          typeof chatInfo === 'object' &&
+          !Array.isArray(chatInfo) &&
+          (chatInfo as Record<string, unknown>).left === true
+        if (isLeftChatInfo) {
+          extractChannelInfo(body, normalizedChatId)
+        }
+        if (chatInfo === undefined || chatInfo === null || isLeftChatInfo) {
           throw new KakaoTalkError('CHATINFO response missing chatInfo', 'get_chat_failed', {
             responseFailureKind: 'transient_or_unknown',
             getChatFailureReason: 'chat_info_absent',

--- a/src/platforms/kakaotalk/client.ts
+++ b/src/platforms/kakaotalk/client.ts
@@ -1104,6 +1104,9 @@ export class KakaoTalkClient {
    * Unlike `getChats()`, this does not depend on the login-time snapshot or
    * LCHATLIST pagination, so a room first observed from a live push can be
    * resolved without interpreting protocol fields outside this SDK.
+   * The returned chat type preserves numeric values and non-empty protocol
+   * strings, including DirectChat, MultiChat, PlusChat, MemoChat, OM, and OD;
+   * unknown non-empty strings are preserved for forward compatibility.
    */
   async getChat(chatId: string): Promise<KakaoChat> {
     const parsedChatId = parseChatId(chatId)

--- a/src/platforms/kakaotalk/client.ts
+++ b/src/platforms/kakaotalk/client.ts
@@ -1113,7 +1113,7 @@ export class KakaoTalkClient {
         const response = await session.getChannelInfo(parsedChatId)
         assertLocoOk(response, 'CHATINFO')
         const body = response.body as Record<string, unknown>
-        if (body.chatInfo === undefined) {
+        if (body.chatInfo === undefined || body.chatInfo === null) {
           throw new KakaoTalkError('CHATINFO response missing chatInfo', 'get_chat_failed', {
             responseFailureKind: 'transient_or_unknown',
             getChatFailureReason: 'chat_info_absent',

--- a/src/platforms/kakaotalk/client.ts
+++ b/src/platforms/kakaotalk/client.ts
@@ -12,6 +12,7 @@ import { isOpenKakaoChatType } from './chat-classifier'
 import { detectImageDimensions } from './image-meta'
 import { sha1Hex } from './media-upload'
 import { LANG, PC_OS_NAME, getLocoDeviceConfig } from './protocol/config'
+import { isSyntheticConnectionClose } from './protocol/login-response'
 import { uploadMediaToLoco, uploadMultiMediaEntry } from './protocol/media-uploader'
 import { LocoSession } from './protocol/session'
 import type { ChatListResponse, LocoPacket, LoginListResponse, SyncState } from './protocol/types'
@@ -41,15 +42,49 @@ export type KakaoSessionEvent =
 export type KakaoPushHandler = (packet: LocoPacket) => void
 export type KakaoSessionEventHandler = (event: KakaoSessionEvent) => void
 
+export type KakaoTalkResponseFailureKind = 'provider_rejection' | 'transient_or_unknown'
+export type KakaoTalkResponseStatusSource = 'packet' | 'body'
+
 export class KakaoTalkError extends Error {
   code: string
   readonly serverStatus?: number
+  readonly responseFailureKind?: KakaoTalkResponseFailureKind
+  readonly responseStatusSource?: KakaoTalkResponseStatusSource
 
-  constructor(message: string, code: string, options?: { cause?: unknown; serverStatus?: number }) {
+  constructor(
+    message: string,
+    code: string,
+    options?: {
+      cause?: unknown
+      serverStatus?: number
+      responseFailureKind?: KakaoTalkResponseFailureKind
+      responseStatusSource?: KakaoTalkResponseStatusSource
+    },
+  ) {
     super(message, options)
     this.name = 'KakaoTalkError'
     this.code = code
     this.serverStatus = options?.serverStatus
+    this.responseFailureKind = options?.responseFailureKind
+    this.responseStatusSource = options?.responseStatusSource
+  }
+}
+
+class LocoResponseError extends Error {
+  readonly serverStatus?: number
+  readonly responseFailureKind: KakaoTalkResponseFailureKind
+  readonly responseStatusSource?: KakaoTalkResponseStatusSource
+
+  constructor(
+    message: string,
+    responseFailureKind: KakaoTalkResponseFailureKind,
+    options?: { serverStatus?: number; responseStatusSource?: KakaoTalkResponseStatusSource },
+  ) {
+    super(message)
+    this.name = 'LocoResponseError'
+    this.serverStatus = options?.serverStatus
+    this.responseFailureKind = responseFailureKind
+    this.responseStatusSource = options?.responseStatusSource
   }
 }
 
@@ -352,10 +387,28 @@ function collectChats(chatDatas: ChatData[], into: ChatData[], seen: Set<string>
   }
 }
 
-function wrapError(error: unknown, code: string): KakaoTalkError {
-  if (error instanceof KakaoTalkError) return error
+function wrapError(error: unknown, code: string, options?: { classifyResponseFailure?: boolean }): KakaoTalkError {
+  if (error instanceof KakaoTalkError) {
+    if (!options?.classifyResponseFailure || error.responseFailureKind) return error
+    return new KakaoTalkError(error.message, error.code, {
+      cause: error.cause ?? error,
+      serverStatus: error.serverStatus,
+      responseFailureKind: 'transient_or_unknown',
+      responseStatusSource: error.responseStatusSource,
+    })
+  }
   const message = error instanceof Error ? error.message : String(error)
-  return new KakaoTalkError(message, code, { cause: error })
+  return new KakaoTalkError(message, code, {
+    cause: error,
+    serverStatus: error instanceof LocoResponseError ? error.serverStatus : undefined,
+    responseStatusSource: error instanceof LocoResponseError ? error.responseStatusSource : undefined,
+    responseFailureKind:
+      error instanceof LocoResponseError
+        ? error.responseFailureKind
+        : options?.classifyResponseFailure
+          ? 'transient_or_unknown'
+          : undefined,
+  })
 }
 
 function isLoginResponseError(
@@ -502,12 +555,27 @@ function isNonZeroLong(v: unknown): boolean {
 // caller-visible error channel (e.g. GETMEM/MEMBER return `[]` for both empty rooms and dead
 // sockets). Throwing here lets executeWithReconnect detect session death and reconnect.
 function assertLocoOk(response: LocoPacket, command: string): void {
+  if (typeof response.statusCode !== 'number' || !Number.isFinite(response.statusCode)) {
+    throw new LocoResponseError(`${command} failed: response status unavailable`, 'transient_or_unknown')
+  }
+  if (isSyntheticConnectionClose(response)) {
+    throw new LocoResponseError(`${command} failed: connection closed`, 'transient_or_unknown', {
+      serverStatus: response.statusCode,
+      responseStatusSource: 'packet',
+    })
+  }
   if (response.statusCode !== 0) {
-    throw new Error(`${command} failed: statusCode=${response.statusCode}`)
+    throw new LocoResponseError(`${command} failed: statusCode=${response.statusCode}`, 'provider_rejection', {
+      serverStatus: response.statusCode,
+      responseStatusSource: 'packet',
+    })
   }
   const bodyStatus = response.body.status
   if (typeof bodyStatus === 'number' && bodyStatus !== 0) {
-    throw new Error(`${command} failed: body.status=${bodyStatus}`)
+    throw new LocoResponseError(`${command} failed: body.status=${bodyStatus}`, 'provider_rejection', {
+      serverStatus: bodyStatus,
+      responseStatusSource: 'body',
+    })
   }
 }
 
@@ -946,6 +1014,7 @@ export class KakaoTalkClient {
         if (options?.all || options?.search || snapshotEmpty) {
           let cursor: ChatListResponse = loginResult
           let pages = 0
+          const requireCompleteList = options?.all === true
 
           while (pages < MAX_PAGES) {
             // Trust eof only when the snapshot had data. When the snapshot was empty
@@ -958,15 +1027,28 @@ export class KakaoTalkClient {
             const lastChatId = bsonToLong(cursor.lastChatId)
 
             const response = await session.getChatList(lastTokenId, lastChatId)
+            if (requireCompleteList) assertLocoOk(response, 'LCHATLIST')
             const body = response.body as unknown as ChatListResponse
+            if (requireCompleteList && !Array.isArray(body.chatDatas)) {
+              throw new Error('LCHATLIST pagination incomplete: chatDatas unavailable')
+            }
             const chatDatas = (body.chatDatas ?? []) as ChatData[]
+            cursor = body
+            pages++
 
-            if (chatDatas.length === 0) break
+            if (chatDatas.length === 0) {
+              if (requireCompleteList && body.eof !== true) {
+                throw new Error('LCHATLIST pagination incomplete: empty non-EOF page')
+              }
+              break
+            }
 
             collectChats(chatDatas, allChats, seenChatIds)
             this.nameCache.ingest(chatDatas)
-            cursor = body
-            pages++
+          }
+
+          if (requireCompleteList && cursor.eof !== true) {
+            throw new Error(`LCHATLIST pagination incomplete after ${pages} pages`)
           }
         }
 
@@ -1023,7 +1105,7 @@ export class KakaoTalkClient {
 
         return formatChat(chat, title, this.nameCache)
       } catch (error) {
-        throw wrapError(error, 'get_chat_failed')
+        throw wrapError(error, 'get_chat_failed', { classifyResponseFailure: true })
       }
     })
   }

--- a/src/platforms/kakaotalk/client.ts
+++ b/src/platforms/kakaotalk/client.ts
@@ -230,7 +230,7 @@ function formatChat(chat: ChatData, title: string | null, nameCache: MemberNameC
 
   return {
     chat_id: chatId,
-    type: chat.t as KakaoChat['type'],
+    type: requiredChatType(chat.t),
     display_name: displayName,
     title,
     active_members: chat.a as number,
@@ -301,7 +301,7 @@ function requiredNonNegativeInteger(value: unknown, field: string): number {
 }
 
 function requiredChatType(value: unknown): KakaoChat['type'] {
-  if (typeof value === 'string' && isOpenKakaoChatType(value)) {
+  if (typeof value === 'string' && value.length > 0) {
     return value
   }
   return requiredNonNegativeInteger(value, 'type')

--- a/src/platforms/kakaotalk/client.ts
+++ b/src/platforms/kakaotalk/client.ts
@@ -44,12 +44,18 @@ export type KakaoSessionEventHandler = (event: KakaoSessionEvent) => void
 
 export type KakaoTalkResponseFailureKind = 'provider_rejection' | 'transient_or_unknown'
 export type KakaoTalkResponseStatusSource = 'packet' | 'body'
+export type KakaoTalkGetChatFailureReason =
+  | 'provider_rejection'
+  | 'synthetic_connection_close'
+  | 'chat_info_absent'
+  | 'transport_or_unknown'
 
 export class KakaoTalkError extends Error {
   code: string
   readonly serverStatus?: number
   readonly responseFailureKind?: KakaoTalkResponseFailureKind
   readonly responseStatusSource?: KakaoTalkResponseStatusSource
+  readonly getChatFailureReason?: KakaoTalkGetChatFailureReason
 
   constructor(
     message: string,
@@ -59,6 +65,7 @@ export class KakaoTalkError extends Error {
       serverStatus?: number
       responseFailureKind?: KakaoTalkResponseFailureKind
       responseStatusSource?: KakaoTalkResponseStatusSource
+      getChatFailureReason?: KakaoTalkGetChatFailureReason
     },
   ) {
     super(message, options)
@@ -67,6 +74,7 @@ export class KakaoTalkError extends Error {
     this.serverStatus = options?.serverStatus
     this.responseFailureKind = options?.responseFailureKind
     this.responseStatusSource = options?.responseStatusSource
+    this.getChatFailureReason = options?.getChatFailureReason
   }
 }
 
@@ -387,14 +395,25 @@ function collectChats(chatDatas: ChatData[], into: ChatData[], seen: Set<string>
   }
 }
 
-function wrapError(error: unknown, code: string, options?: { classifyResponseFailure?: boolean }): KakaoTalkError {
+function wrapError(
+  error: unknown,
+  code: string,
+  options?: { classifyResponseFailure?: boolean; classifyGetChatFailure?: boolean },
+): KakaoTalkError {
   if (error instanceof KakaoTalkError) {
-    if (!options?.classifyResponseFailure || error.responseFailureKind) return error
+    const responseFailureKind =
+      error.responseFailureKind ?? (options?.classifyResponseFailure ? 'transient_or_unknown' : undefined)
+    const getChatFailureReason =
+      error.getChatFailureReason ?? (options?.classifyGetChatFailure ? 'transport_or_unknown' : undefined)
+    if (responseFailureKind === error.responseFailureKind && getChatFailureReason === error.getChatFailureReason) {
+      return error
+    }
     return new KakaoTalkError(error.message, error.code, {
       cause: error.cause ?? error,
       serverStatus: error.serverStatus,
-      responseFailureKind: 'transient_or_unknown',
+      responseFailureKind,
       responseStatusSource: error.responseStatusSource,
+      getChatFailureReason,
     })
   }
   const message = error instanceof Error ? error.message : String(error)
@@ -408,6 +427,13 @@ function wrapError(error: unknown, code: string, options?: { classifyResponseFai
         : options?.classifyResponseFailure
           ? 'transient_or_unknown'
           : undefined,
+    getChatFailureReason: options?.classifyGetChatFailure
+      ? error instanceof LocoResponseError && error.responseFailureKind === 'provider_rejection'
+        ? 'provider_rejection'
+        : error instanceof LocoResponseError && error.responseStatusSource === 'packet' && error.serverStatus === -1
+          ? 'synthetic_connection_close'
+          : 'transport_or_unknown'
+      : undefined,
   })
 }
 
@@ -1087,6 +1113,12 @@ export class KakaoTalkClient {
         const response = await session.getChannelInfo(parsedChatId)
         assertLocoOk(response, 'CHATINFO')
         const body = response.body as Record<string, unknown>
+        if (body.chatInfo === undefined) {
+          throw new KakaoTalkError('CHATINFO response missing chatInfo', 'get_chat_failed', {
+            responseFailureKind: 'transient_or_unknown',
+            getChatFailureReason: 'chat_info_absent',
+          })
+        }
         const chat = channelInfoToChatData(body, normalizedChatId)
         this.nameCache.ingest([chat])
 
@@ -1105,7 +1137,10 @@ export class KakaoTalkClient {
 
         return formatChat(chat, title, this.nameCache)
       } catch (error) {
-        throw wrapError(error, 'get_chat_failed', { classifyResponseFailure: true })
+        throw wrapError(error, 'get_chat_failed', {
+          classifyResponseFailure: true,
+          classifyGetChatFailure: true,
+        })
       }
     })
   }

--- a/src/platforms/kakaotalk/index.test.ts
+++ b/src/platforms/kakaotalk/index.test.ts
@@ -49,6 +49,33 @@ it('KakaoChatSchema is exported from barrel', () => {
   expect(typeof KakaoChatSchema.parse).toBe('function')
 })
 
+it('KakaoChatSchema preserves a non-empty string channel type', () => {
+  for (const channelType of ['DirectChat', 'MultiChat', 'PlusChat', 'MemoChat', 'OM', 'OD', 'FutureChat']) {
+    expect(
+      KakaoChatSchema.parse({
+        chat_id: '300',
+        type: channelType,
+        display_name: null,
+        title: null,
+        active_members: 2,
+        unread_count: 0,
+        last_message: null,
+      }).type,
+    ).toBe(channelType)
+  }
+  expect(() =>
+    KakaoChatSchema.parse({
+      chat_id: '300',
+      type: '',
+      display_name: null,
+      title: null,
+      active_members: 2,
+      unread_count: 0,
+      last_message: null,
+    }),
+  ).toThrow()
+})
+
 it('KakaoMessageSchema is exported from barrel', () => {
   expect(typeof KakaoMessageSchema.parse).toBe('function')
 })

--- a/src/platforms/kakaotalk/index.ts
+++ b/src/platforms/kakaotalk/index.ts
@@ -1,4 +1,5 @@
 export { KakaoTalkClient, KakaoTalkError } from './client'
+export type { KakaoTalkResponseFailureKind, KakaoTalkResponseStatusSource } from './client'
 export { classifyKakaoChat, isOpenKakaoChatType } from './chat-classifier'
 export type { KakaoChatKind } from './chat-classifier'
 export { KakaoCredentialManager, CredentialManager } from './credential-manager'

--- a/src/platforms/kakaotalk/index.ts
+++ b/src/platforms/kakaotalk/index.ts
@@ -1,5 +1,9 @@
 export { KakaoTalkClient, KakaoTalkError } from './client'
-export type { KakaoTalkResponseFailureKind, KakaoTalkResponseStatusSource } from './client'
+export type {
+  KakaoTalkGetChatFailureReason,
+  KakaoTalkResponseFailureKind,
+  KakaoTalkResponseStatusSource,
+} from './client'
 export { classifyKakaoChat, isOpenKakaoChatType } from './chat-classifier'
 export type { KakaoChatKind } from './chat-classifier'
 export { KakaoCredentialManager, CredentialManager } from './credential-manager'

--- a/src/platforms/kakaotalk/protocol/connection.test.ts
+++ b/src/platforms/kakaotalk/protocol/connection.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'bun:test'
+
+import { LocoConnection } from './connection'
+import { encodePacket } from './packet'
+import type { LocoPacket } from './types'
+
+interface ConnectionInternals {
+  socket: {
+    write: (data: Buffer, callback: (error?: Error) => void) => boolean
+  } | null
+  pendingResolvers: Map<number, unknown>
+  timedOutIds: Set<number>
+  onData: (chunk: Buffer) => void
+}
+
+function internals(connection: LocoConnection): ConnectionInternals {
+  return connection as unknown as ConnectionInternals
+}
+
+describe('LocoConnection.sendPacket', () => {
+  it('resolves a response delivered synchronously during write without double settlement', async () => {
+    const connection = new LocoConnection()
+    const owned = internals(connection)
+    const response: LocoPacket = {
+      packetId: 1,
+      statusCode: 0,
+      method: 'FAST',
+      bodyType: 0,
+      body: { accepted: true },
+    }
+    const pushed: LocoPacket[] = []
+    connection.onPush((packet) => pushed.push(packet))
+    owned.socket = {
+      write: (_data, callback) => {
+        owned.onData(encodePacket(response))
+        callback(new Error('late write callback failure'))
+        return false
+      },
+    }
+
+    await expect(connection.sendPacket('FAST')).resolves.toEqual(response)
+    expect(pushed).toEqual([])
+    expect(owned.pendingResolvers.size).toBe(0)
+    expect(owned.timedOutIds.size).toBe(0)
+  })
+
+  it('rejects a write failure and clears only its pending entry', async () => {
+    const connection = new LocoConnection()
+    const owned = internals(connection)
+    const pushed: LocoPacket[] = []
+    const sentinelTimer = setTimeout(() => {}, 60_000)
+    const sentinel = { resolve: () => {}, timer: sentinelTimer }
+    owned.pendingResolvers.set(99, sentinel)
+    connection.onPush((packet) => pushed.push(packet))
+    owned.socket = {
+      write: (_data, callback) => {
+        callback(new Error('socket write failed'))
+        return false
+      },
+    }
+
+    try {
+      await expect(connection.sendPacket('FAIL')).rejects.toThrow('socket write failed')
+      expect(owned.pendingResolvers.size).toBe(1)
+      expect(owned.pendingResolvers.get(99)).toBe(sentinel)
+      expect(owned.timedOutIds.has(1)).toBe(true)
+
+      owned.onData(
+        encodePacket({
+          packetId: 1,
+          statusCode: 0,
+          method: 'FAIL',
+          bodyType: 0,
+          body: { late: true },
+        }),
+      )
+
+      expect(pushed).toEqual([])
+      expect(owned.pendingResolvers.size).toBe(1)
+      expect(owned.pendingResolvers.get(99)).toBe(sentinel)
+      expect(owned.timedOutIds.size).toBe(0)
+    } finally {
+      clearTimeout(sentinelTimer)
+      owned.pendingResolvers.delete(99)
+    }
+  })
+})

--- a/src/platforms/kakaotalk/protocol/connection.ts
+++ b/src/platforms/kakaotalk/protocol/connection.ts
@@ -73,15 +73,28 @@ export class LocoConnection {
 
     const raw = encodePacket(packet)
     const data = this.crypto ? this.crypto.encrypt(raw) : raw
-    await this.write(data)
 
     return new Promise((resolve, reject) => {
+      let entry: {
+        resolve: (packet: LocoPacket) => void
+        timer: ReturnType<typeof setTimeout>
+      }
       const timer = setTimeout(() => {
+        if (this.pendingResolvers.get(packetId) !== entry) return
         this.pendingResolvers.delete(packetId)
         this.timedOutIds.add(packetId)
         reject(new Error(`LOCO packet timeout: ${method} (${DEFAULT_SEND_TIMEOUT_MS}ms)`))
       }, DEFAULT_SEND_TIMEOUT_MS)
-      this.pendingResolvers.set(packetId, { resolve, timer })
+      entry = { resolve, timer }
+      this.pendingResolvers.set(packetId, entry)
+
+      void this.write(data).catch((error: unknown) => {
+        if (this.pendingResolvers.get(packetId) !== entry) return
+        clearTimeout(entry.timer)
+        this.pendingResolvers.delete(packetId)
+        this.timedOutIds.add(packetId)
+        reject(error)
+      })
     })
   }
 

--- a/src/platforms/kakaotalk/protocol/login-response.test.ts
+++ b/src/platforms/kakaotalk/protocol/login-response.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'bun:test'
 
-import { validateLoginListResponse } from './login-response'
+import { isSyntheticConnectionClose, validateLoginListResponse } from './login-response'
 import type { LocoPacket } from './types'
 
 function packet(statusCode: number, body: Record<string, unknown>): LocoPacket {
@@ -54,11 +54,22 @@ describe('LOGINLIST response classification', () => {
   })
 
   it('keeps a synthetic socket close on the transport-error path', () => {
-    const error = captureError(() => validateLoginListResponse(packet(-1, { error: 'connection closed' })))
+    const response = packet(-1, { error: 'connection closed' })
+    const error = captureError(() => validateLoginListResponse(response))
 
+    expect(isSyntheticConnectionClose(response)).toBe(true)
     expect(error).toBeInstanceOf(Error)
     expect(error).toMatchObject({ message: 'KakaoTalk LOGINLIST transport failed: connection closed' })
     expect(error).not.toHaveProperty('code')
     expect(error).not.toHaveProperty('serverStatus')
+  })
+
+  it('does not classify status -1 with a nonmatching body as a synthetic socket close', () => {
+    const response = packet(-1, { error: 'provider rejected' })
+
+    expect(isSyntheticConnectionClose(response)).toBe(false)
+    expect(() => validateLoginListResponse(response)).toThrow(
+      expect.objectContaining({ code: 'login_rejected', serverStatus: -1 }),
+    )
   })
 })

--- a/src/platforms/kakaotalk/protocol/login-response.ts
+++ b/src/platforms/kakaotalk/protocol/login-response.ts
@@ -17,7 +17,7 @@ export class KakaoLoginResponseError extends Error {
   }
 }
 
-function isSyntheticConnectionClose(response: LocoPacket): boolean {
+export function isSyntheticConnectionClose(response: LocoPacket): boolean {
   return response.statusCode === CONNECTION_CLOSED_STATUS && response.body.error === 'connection closed'
 }
 

--- a/src/platforms/kakaotalk/types.ts
+++ b/src/platforms/kakaotalk/types.ts
@@ -71,7 +71,15 @@ export const KAKAO_NEXT_ACTIONS: Record<string, { next_action: string; message: 
 }
 
 export type KakaoOpenChatType = 2 | 13 | 14 | 15 | 16 | 'OM' | 'OD'
-export type KakaoChatType = number | Extract<KakaoOpenChatType, string>
+export const KNOWN_KAKAO_CHAT_STRING_TYPES = ['DirectChat', 'MultiChat', 'PlusChat', 'MemoChat', 'OM', 'OD'] as const
+export type KakaoChatType = number | string
+
+export function isKnownKakaoChatStringType(value: unknown): value is (typeof KNOWN_KAKAO_CHAT_STRING_TYPES)[number] {
+  return (
+    typeof value === 'string' &&
+    KNOWN_KAKAO_CHAT_STRING_TYPES.includes(value as (typeof KNOWN_KAKAO_CHAT_STRING_TYPES)[number])
+  )
+}
 
 export interface KakaoChat {
   chat_id: string
@@ -239,7 +247,7 @@ export interface KakaoTypingResult {
 
 export const KakaoChatSchema = z.object({
   chat_id: z.string(),
-  type: z.union([z.number(), z.literal('OM'), z.literal('OD')]),
+  type: z.union([z.number(), z.string().min(1)]),
   display_name: z.string().nullable(),
   title: z.string().nullable(),
   active_members: z.number(),


### PR DESCRIPTION
## Summary

- fail closed when `getChats({ all: true })` cannot prove pagination reached EOF
- expose privacy-safe packet/body response classification for read-only `getChat`
- classify exact `getChat` failure reasons as allowlisted public metadata, including neutral `chat_info_absent`
- reuse the existing synthetic connection-close predicate

## Validation

- Kakao focused client tests: 133 passed, 0 failed
- TypeScript typecheck: passed
- production build: passed
- changed-file formatter check: passed
- `git diff --check`: passed

No auth, registration, send, protocol codec, crypto, credential, session, listener, or reconnect behavior is changed. Response bodies, identifiers, messages, causes, and secrets are not exposed by the new public metadata.
